### PR TITLE
fix: updated import for node v22

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -3,7 +3,7 @@
 // npm
 import fs from 'fs';
 import path from 'path';
-import pkg from '../package.json' assert { type: "json" };
+import pkg from '../package.json' with { type: "json" };
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // make-icns
-import messages from '../config/messages.json' assert { type: "json" };
+import messages from '../config/messages.json' with { type: "json" };
 // npm
 import 'colors';
 

--- a/lib/image.js
+++ b/lib/image.js
@@ -3,7 +3,7 @@
 // make-icns
 import { getMessage } from './helpers.js';
 import { getFileName, normalizePath } from './files.js';
-import imageList from '../config/imageList.json' assert { type: "json" };
+import imageList from '../config/imageList.json' with { type: "json" };
 
 // npm
 import { Icns, IcnsImage } from '@fiahfy/icns';

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // make-icns
-import pkg from '../package.json' assert { type: "json" };
+import pkg from '../package.json' with { type: "json" };
 // npm
 import updateNotifier from 'update-notifier';
 


### PR DESCRIPTION
updated the import statement. This apparently changed around node v17 and the previosu version no longer runs on latest node